### PR TITLE
Clean some special characters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,16 @@ interface Config {
 }
 
 /**
+ * Replaces characters not allowed in Cloudinary parameter values
+ */
+function cleanText(text: string): string {
+  return text
+    .replace(/%2C/g, '%252C') // comma
+    .replace(/%2F/g, '%252F') // slash
+    .replace(/\./g, '%2e');   // dot
+};
+
+/**
  * Generates a social sharing image with custom text using Cloudinary’s APIs.
  *
  * @see https://cloudinary.com/documentation/image_transformations#adding_text_captions
@@ -64,9 +74,9 @@ export default function generateSocialImage({
     'g_south_west',
     `x_${textLeftOffset}`,
     `y_${titleBottomOffset}`,
-    `l_text:${titleFont}_${titleFontSize}${titleExtraConfig}:${encodeURIComponent(
+    `l_text:${titleFont}_${titleFontSize}${titleExtraConfig}:${cleanText(encodeURIComponent(
       title,
-    )}`,
+    ))}`,
   ].join(',');
 
   // configure the tagline text
@@ -77,9 +87,9 @@ export default function generateSocialImage({
     'g_north_west',
     `x_${textLeftOffset}`,
     `y_${taglineTopOffset}`,
-    `l_text:${taglineFont}_${taglineFontSize}${taglineExtraConfig}:${encodeURIComponent(
+    `l_text:${taglineFont}_${taglineFontSize}${taglineExtraConfig}:${cleanText(encodeURIComponent(
       tagline,
-    )}`,
+    ))}`,
   ].join(',');
 
   // combine all the pieces required to generate a Cloudinary URL

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,13 +22,13 @@ interface Config {
 }
 
 /**
- * Replaces characters not allowed in Cloudinary parameter values
+ * Encodes characters for Cloudinary URL
+ * Encodes some not allowed in Cloudinary parameter values twice:
+ *   hash, comma, slash, question mark, backslash
+ *   https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-slash-character-or-any-other-special-characters-in-text-overlays-
  */
 function cleanText(text: string): string {
-  return text
-    .replace(/%2C/g, '%252C') // comma
-    .replace(/%2F/g, '%252F') // slash
-    .replace(/\./g, '%2e');   // dot
+  return encodeURIComponent(text).replace(/%(23|2C|2F|3F|5C)/g, "%25$1");
 };
 
 /**
@@ -74,9 +74,7 @@ export default function generateSocialImage({
     'g_south_west',
     `x_${textLeftOffset}`,
     `y_${titleBottomOffset}`,
-    `l_text:${titleFont}_${titleFontSize}${titleExtraConfig}:${cleanText(encodeURIComponent(
-      title,
-    ))}`,
+    `l_text:${titleFont}_${titleFontSize}${titleExtraConfig}:${cleanText(title)}`,
   ].join(',');
 
   // configure the tagline text
@@ -87,9 +85,7 @@ export default function generateSocialImage({
     'g_north_west',
     `x_${textLeftOffset}`,
     `y_${taglineTopOffset}`,
-    `l_text:${taglineFont}_${taglineFontSize}${taglineExtraConfig}:${cleanText(encodeURIComponent(
-      tagline,
-    ))}`,
+    `l_text:${taglineFont}_${taglineFontSize}${taglineExtraConfig}:${cleanText(tagline)}`,
   ].join(',');
 
   // combine all the pieces required to generate a Cloudinary URL


### PR DESCRIPTION
Fixes #3 

I had the same issue before with my Jekyll version… 😁

I also considered using 2 `encodeUriComponent()` calls, but some characters would be changed without any need.

It looks however there is no issue with `?` at least.