### PR TITLE
fix: update example and add who is using this section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This utility function accepts a config object. Available options are as follows:
 ### Setting config options
 
 ```js
-const sharingImage = getSharingImage({
+const socialImage = getShareImage({
   title: 'My Post Title',
   tagline: 'A tagline for the post',
   cloudName: 'myusername',

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ const sharingImage = getSharingImage({
   tagline: 'A tagline for the post',
   cloudName: 'myusername',
   imagePublicID: 'my-template-image.jpg',
+  titleExtraConfig: '_bold', // optional - set title font weight to bold
   textColor: '663399', // optional — set the color to purple
 });
 ```
+
+## Who is using this?
+- [Echobind](https://echobind.com/) with their [blog image generator](https://github.com/echobind/blog-image-generator)


### PR DESCRIPTION
This PR updates the settings config example to show how to use `titleExtraConfig` and it adds a section called "Who is using this?" so others can add themselves. 