### PR TITLE
feat: allow title and tag to be offset separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This utility function accepts a config object. Available options are as follows:
 | imageWidth         |          | (number, default `1280`) SEO image width (defaults to Twitter ratio) |
 | imageHeight        |          | (number, default `669`) SEO image height (defaults to Twitter ratio) |
 | textAreaWidth      |          | (number, default `760`) width of title and tagline text areas        |
+| textLeftOffset     |          | (number, default `480`) distance from left edge to start text boxes  |
 | titleLeftOffset    |          | (number, default `480`) distance from left edge to start text boxes  |
 | taglineLeftOffset  |          | (number, default `480`) distance from left edge to start text boxes  |
 | titleBottomOffset  |          | (number, default `254`) distance from bottom to start title text     |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This utility function accepts a config object. Available options are as follows:
 | textAreaWidth      |          | (number, default `760`) width of title and tagline text areas        |
 | textLeftOffset     |          | (number, default `480`) distance from left edge to start text boxes  |
 | titleLeftOffset    |          | (number, `null`) distance from left edge to start text boxes  |
-| taglineLeftOffset  |          | (number, default `null`) distance from left edge to start text boxes  |
+| taglineLeftOffset  |          | (number, default `null`) distance from left edge to start text boxes |
 | titleBottomOffset  |          | (number, default `254`) distance from bottom to start title text     |
 | taglineTopOffset   |          | (number, default `445`) distance from top to start tagline text      |
 | textColor          |          | (string, default `000000`) hex value for text color                  |

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ This utility function accepts a config object. Available options are as follows:
 | imageHeight        |          | (number, default `669`) SEO image height (defaults to Twitter ratio) |
 | textAreaWidth      |          | (number, default `760`) width of title and tagline text areas        |
 | textLeftOffset     |          | (number, default `480`) distance from left edge to start text boxes  |
-| titleLeftOffset    |          | (number, default `480`) distance from left edge to start text boxes  |
-| taglineLeftOffset  |          | (number, default `480`) distance from left edge to start text boxes  |
+| titleLeftOffset    |          | (number, `null`) distance from left edge to start text boxes  |
+| taglineLeftOffset  |          | (number, default `null`) distance from left edge to start text boxes  |
 | titleBottomOffset  |          | (number, default `254`) distance from bottom to start title text     |
 | taglineTopOffset   |          | (number, default `445`) distance from top to start tagline text      |
 | textColor          |          | (string, default `000000`) hex value for text color                  |

--- a/README.md
+++ b/README.md
@@ -95,3 +95,4 @@ const socialImage = getShareImage({
 - [Horacio Herrera](https://horacioh.com)
 - [@chris_berry](https://twitter.com/chris_berry) on his [blog](https://chrisberry.io)
 - [@codebender828](https://twitter.com/codebender828) on his [blog](https://jbakebwa.dev)
+- [@ryan_c_harris](https://twitter.com/ryan_c_harris) on his [blog](https://ryanharris.dev)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ This utility function accepts a config object. Available options are as follows:
 | imageWidth         |          | (number, default `1280`) SEO image width (defaults to Twitter ratio) |
 | imageHeight        |          | (number, default `669`) SEO image height (defaults to Twitter ratio) |
 | textAreaWidth      |          | (number, default `760`) width of title and tagline text areas        |
-| textLeftOffset     |          | (number, default `480`) distance from left edge to start text boxes  |
+| titleLeftOffset    |          | (number, default `480`) distance from left edge to start text boxes  |
+| taglineLeftOffset  |          | (number, default `480`) distance from left edge to start text boxes  |
 | titleBottomOffset  |          | (number, default `254`) distance from bottom to start title text     |
 | taglineTopOffset   |          | (number, default `445`) distance from top to start tagline text      |
 | textColor          |          | (string, default `000000`) hex value for text color                  |

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ interface Config {
   imageWidth?: number;
   imageHeight?: number;
   textAreaWidth?: number;
+  textLeftOffset?: number;
   titleLeftOffset?: number;
   taglineLeftOffset?: number;
   titleBottomOffset?: number;
@@ -52,8 +53,9 @@ export default function generateSocialImage({
   imageWidth = 1280,
   imageHeight = 669,
   textAreaWidth = 760,
-  titleLeftOffset = 480,
-  taglineLeftOffset = 480,
+  textLeftOffset = 480,
+  titleLeftOffset = null,
+  taglineLeftOffset = null,
   titleBottomOffset = 254,
   taglineTopOffset = 445,
   textColor = '000000',
@@ -78,7 +80,7 @@ export default function generateSocialImage({
     'c_fit',
     `co_rgb:${titleColor || textColor}`,
     'g_south_west',
-    `x_${titleLeftOffset}`,
+    `x_${titleLeftOffset || textLeftOffset}`,
     `y_${titleBottomOffset}`,
     `l_text:${titleFont}_${titleFontSize}${titleExtraConfig}:${cleanText(
       title,
@@ -92,7 +94,7 @@ export default function generateSocialImage({
         'c_fit',
         `co_rgb:${taglineColor || textColor}`,
         'g_north_west',
-        `x_${taglineLeftOffset}`,
+        `x_${taglineLeftOffset || textLeftOffset}`,
         `y_${taglineTopOffset}`,
         `l_text:${taglineFont}_${taglineFontSize}${taglineExtraConfig}:${cleanText(
           tagline,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ interface Config {
   imageWidth?: number;
   imageHeight?: number;
   textAreaWidth?: number;
-  textLeftOffset?: number;
+  titleLeftOffset?: number;
+  taglineLeftOffset?: number;
   titleBottomOffset?: number;
   taglineTopOffset?: number;
   textColor?: string;
@@ -51,7 +52,8 @@ export default function generateSocialImage({
   imageWidth = 1280,
   imageHeight = 669,
   textAreaWidth = 760,
-  textLeftOffset = 480,
+  titleLeftOffset = 480,
+  taglineLeftOffset = 480,
   titleBottomOffset = 254,
   taglineTopOffset = 445,
   textColor = '000000',
@@ -76,7 +78,7 @@ export default function generateSocialImage({
     'c_fit',
     `co_rgb:${titleColor || textColor}`,
     'g_south_west',
-    `x_${textLeftOffset}`,
+    `x_${titleLeftOffset}`,
     `y_${titleBottomOffset}`,
     `l_text:${titleFont}_${titleFontSize}${titleExtraConfig}:${cleanText(
       title,
@@ -90,7 +92,7 @@ export default function generateSocialImage({
         'c_fit',
         `co_rgb:${taglineColor || textColor}`,
         'g_north_west',
-        `x_${textLeftOffset}`,
+        `x_${taglineLeftOffset}`,
         `y_${taglineTopOffset}`,
         `l_text:${taglineFont}_${taglineFontSize}${taglineExtraConfig}:${cleanText(
           tagline,


### PR DESCRIPTION
This PR does the following:
1. Removes the `textLeftOffset` param
2. Adds `titleLeftOffset` and `taglineLeftOffset` instead
3. Updates the `README` to include the new params
4. Adds me to the `Who is using this?` section