### PR TITLE
Gravity Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ This utility function accepts a config object. Available options are as follows:
 | imageHeight        |          | (number, default `669`) SEO image height (defaults to Twitter ratio) |
 | textAreaWidth      |          | (number, default `760`) width of title and tagline text areas        |
 | textLeftOffset     |          | (number, default `480`) distance from left edge to start text boxes  |
+| titleGravity       |          | (string, default `south_west`) location the title is anchored from   |
+| taglineGravity     |          | (string, default `north_west`) location the tagline is anchored from |
 | titleLeftOffset    |          | (number, `null`) distance from left edge to start text boxes  |
 | taglineLeftOffset  |          | (number, default `null`) distance from left edge to start text boxes |
 | titleBottomOffset  |          | (number, default `254`) distance from bottom to start title text     |

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ interface Config {
   imageHeight?: number;
   textAreaWidth?: number;
   textLeftOffset?: number;
+  titleGravity?: string;
+  taglineGravity?: string;
   titleLeftOffset?: number;
   taglineLeftOffset?: number;
   titleBottomOffset?: number;
@@ -54,6 +56,8 @@ export default function generateSocialImage({
   imageHeight = 669,
   textAreaWidth = 760,
   textLeftOffset = 480,
+  titleGravity = 'south_west',
+  taglineGravity = 'north_west',
   titleLeftOffset = null,
   taglineLeftOffset = null,
   titleBottomOffset = 254,
@@ -79,7 +83,7 @@ export default function generateSocialImage({
     `w_${textAreaWidth}`,
     'c_fit',
     `co_rgb:${titleColor || textColor}`,
-    'g_south_west',
+    `g_${titleGravity}`,
     `x_${titleLeftOffset || textLeftOffset}`,
     `y_${titleBottomOffset}`,
     `l_text:${titleFont}_${titleFontSize}${titleExtraConfig}:${cleanText(
@@ -93,7 +97,7 @@ export default function generateSocialImage({
         `w_${textAreaWidth}`,
         'c_fit',
         `co_rgb:${taglineColor || textColor}`,
-        'g_north_west',
+        `g_${taglineGravity}`,
         `x_${taglineLeftOffset || textLeftOffset}`,
         `y_${taglineTopOffset}`,
         `l_text:${taglineFont}_${taglineFontSize}${taglineExtraConfig}:${cleanText(


### PR DESCRIPTION
This sets up the ability to pass in a custom option for gravity.

Defaults are what they are today, user option is the direction without including the `g_` similar to other options, so like `north_west`