### PR TITLE
 Update example usage with correct parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ const socialImage = getShareImage({
   tagline: '#devops #nodejs #ssl',
   cloudName: 'jlengstorf',
   imagePublicID: 'lwj/blog-post-card',
-  titleFont: "futura",
-  taglineFont: "futura",
+  titleFont: 'futura',
+  taglineFont: 'futura',
   textColor: '232129',
 });
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ const socialImage = getShareImage({
   tagline: '#devops #nodejs #ssl',
   cloudName: 'jlengstorf',
   imagePublicID: 'lwj/blog-post-card',
-  font: 'futura',
+  titleFont: "futura",
+  taglineFont: "futura",
   textColor: '232129',
 });
 ```


### PR DESCRIPTION
The parameter for font is `font` in the current example. The actual parameters are called `titleFont` and `taglineFont`. This PR updates the readme to reflect that.