### PR TITLE
Fix: remove trailing slash on learnwithjason urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is a utility function that builds social media images by overlaying a title
 
 **This was created as part of an article series:**
 
-- [How to design a social sharing card template](https://www.learnwithjason.dev/blog/design-social-sharing-card/)
-- [How the code in this package works](https://www.learnwithjason.dev/blog/auto-generate-social-image/)
+- [How to design a social sharing card template](https://www.learnwithjason.dev/blog/design-social-sharing-card)
+- [How the code in this package works](https://www.learnwithjason.dev/blog/auto-generate-social-image)
 
 ## Installation
 


### PR DESCRIPTION
Getting a 500 error when blog URLs have a trailing slash:

![Screen Shot 2022-05-13 at 2 08 58 pm](https://user-images.githubusercontent.com/13792200/168210341-2204fe96-56a7-47a0-a21f-4ae132797ec4.png)

Works fine when removed:

![Screen Shot 2022-05-13 at 2 09 13 pm](https://user-images.githubusercontent.com/13792200/168210359-01b364e4-aa1f-4a03-9368-dc2b1bed8f8e.png)

Just a heads up, the URL in the `About` section of this repo also has a trailing slash and 500s. I couldn't fix that one with a PR 👍